### PR TITLE
feat: add logic to download Lume

### DIFF
--- a/lib/sidekick/lume.ex
+++ b/lib/sidekick/lume.ex
@@ -1,6 +1,6 @@
 defmodule Sidekick.Lume do
   @moduledoc ~S"""
-  This module provides an manage the Luma instance and interact with it.
+  This module provides and manage the Luma instance and interact with it.
   """
 
   alias Sidekick.Host

--- a/lib/sidekick/lume.ex
+++ b/lib/sidekick/lume.ex
@@ -3,11 +3,127 @@ defmodule Sidekick.Lume do
   This module provides an manage the Luma instance and interact with it.
   """
 
+  alias Sidekick.Host
+
   require Logger
 
-  @version "0.1.8"
+  @version "0.1.9"
 
-  def download do
-    # download_url = "https://github.com/trycua/lume/releases/download/v#{@version}/lume.pkg.tar.gz"
+  @doc ~s"""
+  It returns the Lume version this version of Sidekick is pinned to.
+  """
+  def version, do: @version
+
+  @doc ~s"""
+  Downloads Lume #{@version} and extracts it into a directory for local usage.
+  The version of Lume is tied to a version of Sidekick for determinism reasons to ease debugging and reasoning
+  about Sidekick.
+
+  ## Parameters
+
+    - `opts`:
+      - `cache_dir`: The cache directory where Lume will be downloaded. When not present, it falls back to the application configuration `[:sidekick, :cache_dir]` or the `sidekick` directory inside the [XDG](https://specifications.freedesktop.org/basedir-spec/latest/) cache home directory.
+
+  ## Returns
+
+  It returns a string path to the Lume binary.
+
+  ## Examples
+
+  In the default XDG cache home directory:
+
+        iex> Sidekick.Lume.download_if_absent()
+        "~/.cache/sidekick/lume/versions/0.1.9/lume"
+  """
+  def download_if_absent(opts \\ []) do
+    binary_path = binary_path(opts)
+    if File.exists?(binary_path), do: binary_path, else: download(opts)
+  end
+
+  @doc ~S"""
+  It returns a `String` path to the Lume binary.
+  """
+  def binary_path(opts) do
+    Path.join(bin_directory(opts), "lume")
+  end
+
+  defp download(opts \\ []) do
+    temporary_directory = Temp.mkdir!()
+    download_path = Path.join(temporary_directory, release_asset_name())
+    download_url = download_url()
+
+    Logger.debug("Downloading Lume from #{download_url} into #{download_path}")
+
+    try do
+      %{status: 200} = Req.get!(download_url, into: File.stream!(download_path))
+
+      extract(download_path, opts)
+    after
+      File.rm_rf!(temporary_directory)
+    end
+
+    make_binaries_executable(opts)
+
+    binary_path(opts)
+  end
+
+  defp make_binaries_executable(opts) do
+    Logger.debug("Making binaries at #{bin_directory(opts)} executable")
+
+    for binary_path <- Path.wildcard(Path.join(bin_directory(opts), "*")) do
+      File.chmod(binary_path, 755)
+    end
+  end
+
+  defp make_binaries_executable(opts) do
+    Logger.debug("Making binaries at #{bin_directory(opts)} executable")
+
+    for binary_path <- Path.wildcard(Path.join(bin_directory(opts), "*")) do
+      File.chmod(binary_path, 755)
+    end
+  end
+
+  defp bin_directory(opts) do
+    directory(opts)
+  end
+
+  defp extract(compressed_file_path, opts) do
+    Logger.debug("Extracting #{compressed_file_path} to #{directory(opts)}")
+
+    :ok =
+      :erl_tar.extract(String.to_charlist(compressed_file_path), [
+        {:cwd, String.to_charlist(directory(opts))},
+        :compressed,
+        :silent
+      ])
+  end
+
+  defp directory(opts) do
+    Path.join(
+      Keyword.get(opts, :cache_dir) || Application.get_env(:sidekick, :cache_dir) ||
+        XDGBasedir.user_cache_dir("sidekick"),
+      "lume/versions/#{@version}/"
+    )
+  end
+
+  defp release_asset_name do
+    arch =
+      case Host.arch() do
+        :x86_64 -> "amd64"
+        :x86 -> "amd64"
+        arch -> "#{arch}"
+      end
+
+    case {Host.os(), arch} do
+      {:macos, arch} ->
+        "lume.tar.gz"
+
+      {_, _} ->
+        raise "Lume doesn't support this OS/arch combination."
+    end
+  end
+
+  defp download_url do
+    "https://github.com/trycua/lume/releases/download/v#{@version}/#{release_asset_name()}"
   end
 end

--- a/test/sidekick/lume_test.exs
+++ b/test/sidekick/lume_test.exs
@@ -1,0 +1,19 @@
+defmodule Sidekick.LumeTest do
+  use ExUnit.Case
+
+  alias Sidekick.Lume
+
+  @tag :tmp_dir
+  test "downloads lume successfully", %{tmp_dir: tmp_dir} do
+    # Lume is a macOS tool.
+    if Sidekick.Host == :macos do
+      # When
+      executable_path = Lume.download_if_absent(cache_dir: tmp_dir)
+
+      # Then
+      assert File.exists?(executable_path)
+      {stdout, 0} = System.cmd(executable_path, ["--version"])
+      assert String.contains?(stdout, Lume.version())
+    end
+  end
+end


### PR DESCRIPTION
I'm adding the logic to download [Lume](https://github.com/trycua/lume) in the same way I did for [Podman](https://github.com/trycua/lume). 

In a follow-up PR I'll start building the interface that the server will interact with.